### PR TITLE
Add support for multiple gmail accounts

### DIFF
--- a/manifest.dev.chrome.json
+++ b/manifest.dev.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Gmail Quick Links",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/manifest.dev.chrome.json
+++ b/manifest.dev.chrome.json
@@ -16,6 +16,7 @@
   "content_scripts": [
      {
        "matches": ["https://mail.google.com/*"],
+       "css": ["default.css"],
        "js": ["dev.gmailquicklinks.bundle.js"],
        "run_at": "document_idle"
      }

--- a/manifest.dev.chrome.json
+++ b/manifest.dev.chrome.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Gmail Quick Links",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/manifest.dev.ff.json
+++ b/manifest.dev.ff.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Gmail Quick Links",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/manifest.dev.ff.json
+++ b/manifest.dev.ff.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Gmail Quick Links",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/manifest.dist.json
+++ b/manifest.dist.json
@@ -16,6 +16,7 @@
   "content_scripts": [
      {
        "matches": ["https://mail.google.com/*"],
+       "css": ["default.css"],
        "js": ["dist.gmailquicklinks.bundle.js"],
        "run_at": "document_idle"
      }

--- a/manifest.dist.json
+++ b/manifest.dist.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Gmail Quick Links",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/manifest.dist.json
+++ b/manifest.dist.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Gmail Quick Links",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gmail-quick-links",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gmail-quick-links",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gmail-quick-links",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "a replacement for Gmail Quick Links",
   "keywords": [
     "chrome extension",
@@ -11,7 +11,6 @@
   "scripts": {
     "dev:ff": "webpack --config webpack.dev.ff.js --watch",
     "dev:chrome": "webpack --config webpack.dev.chrome.js --watch",
-
     "dist:ff": "webpack --config webpack.dist.ff.js",
     "dist:chrome": "webpack --config webpack.dist.chrome.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gmail-quick-links",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "a replacement for Gmail Quick Links",
   "keywords": [
     "chrome extension",

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -7,6 +7,7 @@ import {
   addQuickLink,
   removeGlobalLink,
   removeAccountLink,
+  toggleLink,
   GMAIL_QUICK_LINKS_NAME
 } from './config'
 
@@ -87,6 +88,9 @@ class AppContainer extends React.Component {
             } else {
               removeAccountLink(accountName, name)
             }
+          }}
+          onClickGlobeCircle={(type, name) => {
+            toggleLink(type, name, accountName)
           }}
         />
       </div>

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -5,7 +5,8 @@ import {
   storage,
   getQuickLinks,
   addQuickLink,
-  removeLink,
+  removeGlobalLink,
+  removeAccountLink,
   GMAIL_QUICK_LINKS_NAME
 } from './config'
 
@@ -80,7 +81,13 @@ class AppContainer extends React.Component {
           linkList={linkList}
           accountList={accountList[accountName]}
           onAdd={this.onAdd}
-          onDelete={name => removeLink(accountName, name)}
+          onDelete={(type, name) => {
+            if (type === 'global') {
+              removeGlobalLink(name)
+            } else {
+              removeAccountLink(accountName, name)
+            }
+          }}
         />
       </div>
     )

--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -17,7 +17,12 @@ class AppContainer extends React.Component {
     this.state = {
       name: "",
       version: "",
-      linkList: {}
+
+      //global
+      linkList: {},
+
+      //accountList contains all accounts, with nested lists in each account
+      accountList: {}
     }
   }
 
@@ -25,29 +30,33 @@ class AppContainer extends React.Component {
     const {
       name = GMAIL_QUICK_LINKS_NAME.name,
       version = GMAIL_QUICK_LINKS_NAME.version,
-      linkList = []
+      linkList = {},
+      accountList = {}
     } = gql
 
     this.setState((prevState, props) => {
       return {
         name,
         version,
-        linkList
+        linkList,
+        accountList
       }
     })
   }
 
   onAdd(event) {
     event.preventDefault()
+    const { accountName } = this.props
     //TODO: do we use location.hash?  or something else?
     const urlHash = location.hash
     const name = prompt(`Enter title for current view [${urlHash.substring(1)}]`, urlHash.substring(1))
 
     if (name) {
-      addQuickLink({
+      addQuickLink(
+        accountName,
         name,
         urlHash
-      })
+      )
     }
   }
 
@@ -63,13 +72,15 @@ class AppContainer extends React.Component {
   }
 
   render() {
-    const { linkList } = this.state
+    const { linkList, accountList } = this.state
+    const { accountName } = this.props
     return (
       <div id={GMAIL_QUICK_LINKS_NAME.divId}>
         <LinkList
           linkList={linkList}
+          accountList={accountList[accountName]}
           onAdd={this.onAdd}
-          onDelete={name => removeLink(name)}
+          onDelete={name => removeLink(accountName, name)}
         />
       </div>
     )

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,8 +1,21 @@
 import React from 'react'
 
-const Link = ({ type, name, urlHash, onClickLink, onDelete }) => {
+const renderGlobeCircle = type => onClickGlobeCircle => {
   return (
-    <div className="pm">
+    <span
+      className={'glyph ' + ((type == 'global') ? 'global' : 'circle')}
+      onClick={event => onClickGlobeCircle()}
+    />
+  )
+}
+
+const Link = ({ type, name, urlHash, onClickLink, onDelete, onClickGlobeCircle }) => {
+  return (
+    <div
+      style={{
+        paddingBottom: "1px"
+      }}
+      className="pm">
       <a
         style={{
           color: getComputedStyle(document.getElementsByClassName("pU")[0]).color
@@ -17,15 +30,12 @@ const Link = ({ type, name, urlHash, onClickLink, onDelete }) => {
         }
       </a>
       <span
-        className="pl"
-        style={{
-          float: "right",
-          cursor: "pointer",
-          color: getComputedStyle(document.getElementsByClassName("pU")[0]).color
-        }}
-        onClick={event => onDelete(name)}>
-        x
-      </span>
+        className="glyph delete"
+        onClick={event => onDelete()}
+      />
+      {
+        renderGlobeCircle(type)(onClickGlobeCircle)
+      }
     </div>
   )
 }

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -4,6 +4,7 @@ const renderGlobeCircle = type => onClickGlobeCircle => {
   return (
     <span
       className={'glyph ' + ((type == 'global') ? 'global' : 'circle')}
+      title="toggle global/single"
       onClick={event => onClickGlobeCircle()}
     />
   )
@@ -21,12 +22,14 @@ const Link = ({ type, name, urlHash, onClickLink, onDelete, onClickGlobeCircle }
           color: getComputedStyle(document.getElementsByClassName("pU")[0]).color
         }}
         className="po"
+        title={urlHash}
         href={urlHash}
       >
         {name}
       </a>
       <span
         className="glyph delete"
+        title="delete"
         onClick={event => onDelete()}
       />
       {

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const Link = ({ name, urlHash, onClickLink, onDelete }) => {
+const Link = ({ type, name, urlHash, onClickLink, onDelete }) => {
   return (
     <div className="pm">
       <a
@@ -8,8 +8,13 @@ const Link = ({ name, urlHash, onClickLink, onDelete }) => {
           color: getComputedStyle(document.getElementsByClassName("pU")[0]).color
         }}
         className="po"
-        href={urlHash}>
-        {name}
+        href={urlHash}
+      >
+        {
+          (type === "global")
+            ? 'g - ' + name
+            : name
+        }
       </a>
       <span
         className="pl"

--- a/src/components/Link.js
+++ b/src/components/Link.js
@@ -23,11 +23,7 @@ const Link = ({ type, name, urlHash, onClickLink, onDelete, onClickGlobeCircle }
         className="po"
         href={urlHash}
       >
-        {
-          (type === "global")
-            ? 'g - ' + name
-            : name
-        }
+        {name}
       </a>
       <span
         className="glyph delete"

--- a/src/components/LinkList.js
+++ b/src/components/LinkList.js
@@ -105,6 +105,7 @@ const LinkList = ({
         <div className="pv" style={style.quick}>
           <span
             className="glyph info"
+            title="info/help"
             onClick={displayHelp}
             >
           </span>
@@ -120,6 +121,7 @@ const LinkList = ({
           <div
             className="QOxrP pU"
             style={{fontSize:"100%"}}
+            title="Add Quick Link"
             onClick={event => onAdd(event)}>
             Add Quick Link
           </div>

--- a/src/components/LinkList.js
+++ b/src/components/LinkList.js
@@ -23,7 +23,12 @@ const style = {
   }
 }
 
-const renderList = linkList => accountList => onDelete => {
+const renderList = linkList => accountList => onDelete => onClickGlobeCircle => {
+
+  const _onDelete = (type, key) => () => onDelete(type, key)
+  const _onClickGlobeCircle = (type, key) => () => onClickGlobeCircle(type, key)
+
+
   if (Object.keys(linkList).length === 0 && Object.keys(accountList).length === 0) {
     return (
       <div className="pU" style={{fontSize:"100%", textAlign:"left", cursor: "auto"}}>
@@ -42,8 +47,8 @@ const renderList = linkList => accountList => onDelete => {
             type="global"
             name={key}
             urlHash={urlHash}
-            onDelete={() => onDelete('global', key)}
-            onClickGlobeCircle={() => console.log('clicked global', key)}
+            onDelete={_onDelete('global', key)}
+            onClickGlobeCircle={_onClickGlobeCircle('global', key)}
           />
         )
       })
@@ -58,8 +63,8 @@ const renderList = linkList => accountList => onDelete => {
               type="account"
               name={key}
               urlHash={urlHash}
-              onDelete={() => onDelete('account', key)}
-              onClickGlobeCircle={() => console.log('clicked account', key)}
+              onDelete={_onDelete('account', key)}
+              onClickGlobeCircle={_onClickGlobeCircle('account', key)}
             />
           )
         })
@@ -70,7 +75,13 @@ const renderList = linkList => accountList => onDelete => {
   }
 }
 
-const LinkList = ({ linkList = {}, accountList = {}, onAdd, onDelete }) => {
+const LinkList = ({
+  linkList = {},
+  accountList = {},
+  onAdd,
+  onDelete,
+  onClickGlobeCircle
+}) => {
   return (
     <div className="ApVoH">
 
@@ -83,7 +94,7 @@ const LinkList = ({ linkList = {}, accountList = {}, onAdd, onDelete }) => {
       <div id="listContainer">
         <div className="pt">
           <div className="pn" style={style.list}>
-            { renderList(linkList)(accountList)(onDelete) }
+            { renderList(linkList)(accountList)(onDelete)(onClickGlobeCircle) }
           </div>
           <div
             className="QOxrP pU"

--- a/src/components/LinkList.js
+++ b/src/components/LinkList.js
@@ -23,31 +23,52 @@ const style = {
   }
 }
 
-const renderList = linkList => onDelete => {
-  if (Object.keys(linkList).length === 0) {
+const renderList = linkList => accountList => onDelete => {
+  if (Object.keys(linkList).length === 0 && Object.keys(accountList).length === 0) {
     return (
       <div className="pU" style={{fontSize:"100%", textAlign:"left", cursor: "auto"}}>
         nothing to list: To add one, enter a gmail search and click "Add Quick Link" to create a quick list
       </div>
     )
   } else {
-    return (
-      Object.keys(linkList).map(key => {
+
+    const linksArray = Object
+      .keys(linkList)
+      .map(key => {
         const { urlHash } = linkList[key]
         return (
           <Link
             key={key}
+            type="global"
             name={key}
             urlHash={urlHash}
             onDelete={name => onDelete(name)}
           />
         )
       })
+
+      const accountArray = Object
+        .keys(accountList)
+        .map(key => {
+          const { urlHash } = accountList[key]
+          return (
+            <Link
+              key={key}
+              type={"account"}
+              name={key}
+              urlHash={urlHash}
+              onDelete={name => onDelete(name)}
+            />
+          )
+        })
+
+    return (
+      linksArray.concat(accountArray)
     )
   }
 }
 
-const LinkList = ({ linkList = [], onAdd, onDelete }) => {
+const LinkList = ({ linkList = {}, accountList = {}, onAdd, onDelete }) => {
   return (
     <div className="ApVoH">
 
@@ -60,7 +81,7 @@ const LinkList = ({ linkList = [], onAdd, onDelete }) => {
       <div id="listContainer">
         <div className="pt">
           <div className="pn" style={style.list}>
-            { renderList(linkList)(onDelete) }
+            { renderList(linkList)(accountList)(onDelete) }
           </div>
           <div
             className="QOxrP pU"

--- a/src/components/LinkList.js
+++ b/src/components/LinkList.js
@@ -42,7 +42,8 @@ const renderList = linkList => accountList => onDelete => {
             type="global"
             name={key}
             urlHash={urlHash}
-            onDelete={name => onDelete(name)}
+            onDelete={() => onDelete('global', key)}
+            onClickGlobeCircle={() => console.log('clicked global', key)}
           />
         )
       })
@@ -54,10 +55,11 @@ const renderList = linkList => accountList => onDelete => {
           return (
             <Link
               key={key}
-              type={"account"}
+              type="account"
               name={key}
               urlHash={urlHash}
-              onDelete={name => onDelete(name)}
+              onDelete={() => onDelete('account', key)}
+              onClickGlobeCircle={() => console.log('clicked account', key)}
             />
           )
         })

--- a/src/components/LinkList.js
+++ b/src/components/LinkList.js
@@ -75,6 +75,22 @@ const renderList = linkList => accountList => onDelete => onClickGlobeCircle => 
   }
 }
 
+const displayHelp = () => {
+  const message = `
+To use Quick Links:
+
+1) perform a gmail search
+2) click on "Add Quick Link" to give a name for that search
+
+By default, all quick links are specific to the account where they were created.  If you have multiple gmail accounts logged in simultaneously, creating a quick link would only be visible for that account.
+
+You may choose to have quick links available for multiple gmail accounts by clicking on the yellow sphere which then toggles to a globe icon.  A quick link with a globe icon will now show up in every gmail account you are logged in.  Clicking on the globe again will change that quick link back to a specific account quick link.
+
+If you do not have multiple gmail accounts, toggling between the yellow sphere and the globe does nothing.
+`
+  alert(message)
+}
+
 const LinkList = ({
   linkList = {},
   accountList = {},
@@ -87,6 +103,11 @@ const LinkList = ({
 
       <div className="r">
         <div className="pv" style={style.quick}>
+          <span
+            className="glyph info"
+            onClick={displayHelp}
+            >
+          </span>
           <h2 className="pw">Quick Links</h2>
         </div>
       </div>

--- a/src/config.js
+++ b/src/config.js
@@ -14,30 +14,88 @@ export const getGmailLocationToInject = () => {
   return document.querySelector("div.wT")
 }
 
+/*
+the storage looks something like this:
+
+{
+  // this is global for all accounts, universal linkList
+  linkList: {
+    'unread': {
+      urlHash: "#search/label%3Aunread+label%3Ainbox"
+    }
+  },
+
+  // these are specific to each account, with each account having own linkList
+  accountList: {
+    'home_account@example.com': {
+      family: {
+        urlHash: "from:sister OR from:mom"
+      },
+      friends: {
+        urlHash: "from:bestfriend1 OR from:bestfriend2"
+    }
+    },
+    'work_account@example.com': {
+      tps: {
+        urlHash: "#search/tpsReports"
+      },
+      boss: {
+        urlHash: "from:boss@company.com"
+      }
+    }
+  }
+}
+*/
+
+
 export const getQuickLinks = callback => {
   storage.sync.get(null, callback)
 }
 
 //TODO: we need to check for chrome.runtime errors, promisify everything?
-export const addQuickLink = ({ name, urlHash }) => {
-  getQuickLinks(item => {
-    storage.sync.set({
-      linkList: {
-        ...item.linkList,
-        [name]: {
-          urlHash
+export const addQuickLink = (accountName, name, urlHash ) => {
+  getQuickLinks(dataset => {
+    // does the accountName already exist?
+    if (dataset.accountList && dataset.accountList[accountName]) {
+      // yes, then just add another property to the existing accountName
+      storage.sync.set({
+        accountList: {
+          ...dataset.accountList,
+          [accountName]: {
+            ...dataset.accountList[accountName],
+            [name]: {
+              urlHash
+            }
+          }
         }
-      }
-    })
+      })
+    } else {
+      // no, create the accountName and add the first property
+      storage.sync.set({
+        accountList: {
+          ...dataset.accountList,
+          [accountName]: {
+            [name]: {
+              urlHash
+            }
+          }
+        }
+      })
+    }
   })
 }
 
-export const removeLink = name => {
-  getQuickLinks(item => {
+export const removeLink = (accountName, name) => {
+  getQuickLinks(dataset => {
+
     // removes the 'name' ES7 style!
-    const { [name]: deleted, ...links } = item.linkList
+    const { [name]: deleted, ...links } = dataset.accountList[accountName]
+
     storage.sync.set({
-      linkList: links
+      accountList: {
+        ...dataset.accountList,
+        [accountName]: links
+      }
     })
   })
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 export const GMAIL_QUICK_LINKS_NAME = {
   name: "Gmail Quick Links",
   divId: "gmailQuickLinks",
-  version: "0.2.0"
+  version: "0.2.1"
 }
 
 // this should come out of chrome.storage apis

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,7 @@
 export const GMAIL_QUICK_LINKS_NAME = {
   name: "Gmail Quick Links",
   divId: "gmailQuickLinks",
-  version: "0.1.1"
+  version: "0.2.0"
 }
 
 // this should come out of chrome.storage apis

--- a/src/config.js
+++ b/src/config.js
@@ -85,17 +85,34 @@ export const addQuickLink = (accountName, name, urlHash ) => {
   })
 }
 
-// export const toggleLink = (type, name, accountName) => {
-//   if (type === 'global') {
-//     // then make it NOT global
-//     getQuickLinks(dataset => {
-//
-//     })
-//   } else {
-//     // else make it global
-//   }
-//
-// }
+export const toggleLink = (type, name, accountName) => {
+  if (type === 'global') {
+    // then make it NOT global
+    getQuickLinks(dataset => {
+      const { urlHash } = dataset.linkList[name]
+      addQuickLink(accountName, name, urlHash)
+      removeGlobalLink(name)
+    })
+  } else {
+    // else make it global
+    getQuickLinks(dataset => {
+      const { urlHash } = dataset.accountList[accountName][name]
+
+      // remove the local account
+      removeAccountLink(accountName, name)
+
+      // now add it globally
+      storage.sync.set({
+        linkList: {
+          ...dataset.linkList,
+          [name]: {
+            urlHash
+          }
+        }
+      })
+    })
+  }
+}
 
 export const removeGlobalLink = name => {
   getQuickLinks(item => {

--- a/src/config.js
+++ b/src/config.js
@@ -85,7 +85,29 @@ export const addQuickLink = (accountName, name, urlHash ) => {
   })
 }
 
-export const removeLink = (accountName, name) => {
+// export const toggleLink = (type, name, accountName) => {
+//   if (type === 'global') {
+//     // then make it NOT global
+//     getQuickLinks(dataset => {
+//
+//     })
+//   } else {
+//     // else make it global
+//   }
+//
+// }
+
+export const removeGlobalLink = name => {
+  getQuickLinks(item => {
+    // removes the 'name' ES7 style!
+    const { [name]: deleted, ...links } = item.linkList
+    storage.sync.set({
+      linkList: links
+    })
+  })
+}
+
+export const removeAccountLink = (accountName, name) => {
   getQuickLinks(dataset => {
 
     // removes the 'name' ES7 style!

--- a/src/default.css
+++ b/src/default.css
@@ -1,0 +1,32 @@
+span.glyph {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+
+span.global {
+  /*https://icons8.com/icon/12193/globe*/
+  background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAACUklEQVQ4T6VTUUgTcRz+/rESu920QI314NmSHrSmoJHBIAXXQy+tyF5ybm+6E1JyPbrt+QYatO2trbEnCfTFhwzcQMhqPWwoUal0e3CUQunublKNLv437mgZEfR7uvvf9333+33f70/wn0V+53MzaiPq5ABUXCEEXfS7qiIHggy+mkPiJNn7lVMjwEVkD/BjhhDSSEEdJ/II9fqhfDdj6kUUO+WWPeDIpMibE7qIIUDJbZaN+C1bCsxRGZntQWSKV/HE6US6OIjIuh+9zc+xe9CMD6V2ry6iCdC2WxrfF4RL45ZyhcH0awGMSYZSMaPfuoS5LTea6j8i5nBr3fhW4vuycpqj41QFItLs+Hnhbr/1GV7uXMbuwSlwlk0Es2FjXI7dRKjnvtYd7ejhmv+ByLMTVYGolEsOuOyMSTEIonQG01kB5QqL4yYJMceIRtbr5tOlnMiz3ZrAxfiGStujpVQYBLICROmsAR6yJTFkS9UENraSxCtvO9EE2qKSGu4bRbro1ECLhRs14JhjGE31n2rOplajSA93VwXoCIxJst+2pbD+xa6Z9+bzBY1AZw/3+WrItEv38nxe9LFduolBQhCgqFDPPXScXNPMTLwb1QylCdA09DEWCy48ejsWEnk2aMRI6iQRIA3eczFca503/BhZrj7TejzgQpku1WqkJCvWViPGapSyhxA1rudNz+a27mg7oBffKYD+/dAi6QAuWrpOgATfGW4QJdshMwF1XwU8os+yoHP+fJmOyRMgoGJ2ClSBPFQs4Jt59q+Xqcbqf3z5Cdt38hGZ9VMEAAAAAElFTkSuQmCC");
+  background-repeat: no-repeat;
+  float: right;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+span.delete {
+  /*https://icons8.com/icon/11997/delete*/
+  background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAAlElEQVQ4T62TwRGAIAwEL3/asQILQTvTQrQB2/EfB1An6MFD9JuwOTYoaPyk8Tz+Bex9N0Ghbt1GlozVswSxAeKhOj0hdw06u2UbrgGvKzBI6XCAUAcWAgk94vGYXExwFQwkjMliWz/FLSQAfAxJnFQT2DunRi6WOmDCatvhayTCShACAOyerbDTS1b/9yl/+bGaExzwjmgRWfhWGQAAAABJRU5ErkJggg==");
+  background-repeat: no-repeat;
+  float: right;
+  cursor: pointer;
+  margin-left: 10px;
+}
+
+span.circle {
+  /*https://icons8.com/icon/40192/sphere*/
+  background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABRUlEQVQ4T6WS4U3DMBCF72wpQSqNwwR0A9K/kIqwQZmg3YAwAWxARgiTENQgfhImADaI2yLUqvEhl7pKICmV4r/2fe+d30NoebDlPNQCpk/dsSJ2hQCeFiCAjIGKHH92/1uwAqAXcOWneECgD0Yq6g7miR6YTQ4DhSwkwGPRkRfYh9yAKoA8FRlDFTlns7huNZk6GjJyfdn/A9CXABAIfzrc9S/5RCSMqdiIbB1odU5FaGw3QfQ6BfI742ILkKkg4cu9Uim/3Rvw9XzQWxR24vqyVwv4bwU5cW4BwdPpFMgj15friEsOnJAIz92BvCzvr5WXyhoR4bXNF95iZce1n6iH6mLMU/GOQJnFl+FyZY0JcWjUKw7WjfspUgIEb5wXUfd0/miKVCC/AYAj0ZFBY5GM9U2VQwQ42VT5talge8W2q1itAd/7BqERwkvHKwAAAABJRU5ErkJggg==");
+  background-repeat: no-repeat;
+  float: right;
+  cursor: pointer;
+  margin-left: 10px;
+}

--- a/src/default.css
+++ b/src/default.css
@@ -30,3 +30,11 @@ span.circle {
   cursor: pointer;
   margin-left: 10px;
 }
+
+span.info {
+  /*https://icons8.com/icon/34698/information*/
+  background:url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAABEUlEQVQ4T2NkwAMCKrYrgKQ3dHg+wKWMEZdEQu/xSaKiouEg+devX69cUGyZh00tTgOypp6/rKikqAPSdP/e/SvTsg11STIguf/kCQ0NdXOQphs3bp6cW2huQZIBEW0HbDnY2KpBmn78+tW6osrhMFEGgAKOi5+znuE/03+4BiaGXcsq7FYQZYBPxWYHFRXl/Xz8/Ay8PNxgPc+eP1/Yn6SZQJQBAQ37Bf78+GIgIytToKyk6E+yATBbCuddXyAlKRk/agAZYQBLB9xcPAZqaioGoEC8devOha9fv53/9ulrE3rGwsgLsHTAzQ1JAzDw9etXhjt37jpu6fA9gCyOYQAsHWBLNCwcPBc2NDh+QJYDAC3ziRELKKRTAAAAAElFTkSuQmCC");
+  background-repeat: no-repeat;
+  float: left;
+  cursor: pointer;
+}

--- a/src/default.css
+++ b/src/default.css
@@ -10,7 +10,7 @@ span.global {
   background-repeat: no-repeat;
   float: right;
   cursor: pointer;
-  margin-left: 10px;
+  margin-left: 5px;
 }
 
 span.delete {
@@ -19,7 +19,7 @@ span.delete {
   background-repeat: no-repeat;
   float: right;
   cursor: pointer;
-  margin-left: 10px;
+  margin-left: 5px;
 }
 
 span.circle {

--- a/src/index.js
+++ b/src/index.js
@@ -5,9 +5,9 @@ import AppContainer from './AppContainer'
 
 import { getGmailLocationToInject } from './config'
 
-const beginReact = () => {
+const beginReact = accountName => {
   render(
-    <AppContainer />,
+    <AppContainer accountName={accountName}/>,
     document.getElementById('gmailQuickLinksContainer')
   )
 }
@@ -25,7 +25,13 @@ const checkDomElementExist = setInterval(() => {
 
     console.log('Loaded Gmail Quick Links')
 
+    //TODO: what is the person isn't signed in?  Does this crash extension?
+    const currentAccountName = document
+      .querySelectorAll('a[title^="Google Account"]')[0]
+      .title
+      .match(/\(([^)]+)\)/)[1]
+
     //load react
-    beginReact()
+    beginReact(currentAccountName)
   }
 }, 200)

--- a/webpack.dev.chrome.js
+++ b/webpack.dev.chrome.js
@@ -21,6 +21,9 @@ module.exports = merge(common, {
       },{
         from: './src/assets/icon48.png',
         to: './assets/icon48.png'
+      },{
+        from: './src/default.css',
+        to: './default.css'
       }
     ]),
   ]

--- a/webpack.dist.chrome.js
+++ b/webpack.dist.chrome.js
@@ -28,6 +28,9 @@ module.exports = merge(common, {
       },{
         from: './src/assets/icon48.png',
         to: './assets/icon48.png'
+      },{
+        from: './src/default.css',
+        to: './default.css'
       }
     ]),
     // new minify()


### PR DESCRIPTION
Add support for multiple gmail accounts

Quick links now default to the account where they were created.  Quick links can also now be toggled such that they are made available across all logged in gmail accounts.