### PR TITLE
Update querySelector for 'gmailAccountName'.

### DIFF
--- a/src/gmailNodes.js
+++ b/src/gmailNodes.js
@@ -6,7 +6,7 @@ const getGmailLocationToInject = () => {
 
 const gmailAccountName = () =>
   document
-    .querySelector('a[class="gb_x gb_Ea gb_f"]')
+    .querySelector('a[aria-label*="Google Account"]')
     .attributes['aria-label'].nodeValue.match(/\(([^)]+)\)/)[1]
 
 //inside gmail controls container - contains labels such as inbox/starred/drafts/etc


### PR DESCRIPTION
New `querySelector` for `gmailAccountName` does not use the __class__ attribute to help reduce breakage frequency due to Gmail updates.

**Disclaimer:** I have not tested these changes with the plugin. I have only tested lines 7-10 through DevTools Console. It's _very_ likely that other `querySelectors` are broken as well.

Fixes #37.