### PR TITLE
Add confirmation dialog to link deletion. Fixes #32.

### DIFF
--- a/src/AppContainer.js
+++ b/src/AppContainer.js
@@ -132,10 +132,12 @@ class AppContainer extends React.Component {
           accountList={accountList[accountName]}
           onAdd={this.onAdd}
           onDelete={(type, name) => {
-            if (type === 'global') {
-              removeGlobalLink(name)
-            } else {
-              removeAccountLink(accountName, name)
+            if (confirm('Delete quick link "' + name + '"?')) {
+              if (type === 'global') {
+                removeGlobalLink(name)
+              } else {
+                removeAccountLink(accountName, name)
+              }
             }
           }}
           onClickGlobeCircle={(type, name) => {


### PR DESCRIPTION
Hi @kevinwucodes! I am a happy user of this excellent extension, and in the spirit of [Hacktoberfest](https://hacktoberfest.digitalocean.com), I wanted to see if I could help extend it.

For starters I took a look at #32, and I have deleted a confirmation window for deleting quick links. I think the use of the browser's `confirm` function is adequate here, especially since deleting links should be infrequent. But I'm curious what you think, and I can tweak the approach if you like.

Thanks!