### PR TITLE
Fix left pane load check

### DIFF
--- a/manifest.dist.json
+++ b/manifest.dist.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Gmail Quick Links",
-  "version": "0.3.20",
+  "version": "0.3.21",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/src/gmailNodes.js
+++ b/src/gmailNodes.js
@@ -1,7 +1,7 @@
 const getGmailLocationToInject = () => {
   // where we want to put the search quick links
   // this has be be defined after the page loads and becomes ready
-  return document.querySelector('div.wT')
+  return document.querySelector('#\\:mh')
 }
 
 const gmailAccountName = () =>


### PR DESCRIPTION
#51 

Fix check for left pane load. Use ID instead of class name which is also being used for splash screen by Google causing append to be tried before load.