### PR TITLE
Update to Google Manifest Version 3

### DIFF
--- a/manifest.dev.json
+++ b/manifest.dev.json
@@ -1,7 +1,7 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Gmail Quick Links",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {

--- a/manifest.dist.json
+++ b/manifest.dist.json
@@ -1,7 +1,7 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "Gmail Quick Links",
-  "version": "0.3.21",
+  "version": "0.3.22",
   "description": "a replacement for Gmail Quick Links",
   "short_name": "Gmail Links",
   "icons": {


### PR DESCRIPTION
Google is warning users that this extension is out of compliance. It looks like the reason might be that it is still on version 2 of the extension manifest standard. This simply updates the manifest version and the version of the extension. No actual functionality has been changed.